### PR TITLE
Removed unnecessary ui elements and moved the "give kudos to all" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Firefox Add-on aims to provide some tweaks for the Strava Website.
 
 ## Give Kudos to All
 
-A button in the upper left of every Strava page can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!
+A button at top of your activity feed that can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!
 
 ## Remove Clutter
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,22 @@ This Firefox Add-on aims to provide some tweaks for the Strava Website.
 ## Give Kudos to All
 
 A button in the upper left of every Strava page can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!
+
+## Remove Clutter
+
+Removes all social media and premium clutter from the dashboard and activity pages, such as:
+
+- "Find friends"
+- "Upcoming events"
+- "Discover more"
+- "Follow suggestions"
+- Promotional footer at the bottom
+- "Shop" link
+- "Get Premium" link
+- Social media dropdown menu in activity feed
+- "Create target" link
+- Social media buttons on activity detail page
+
+## UI tweaks
+
+Pin the top navigation to the top! Scroll and don't get lost!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Strava Helper
 
-This Firefox Add-on aims to provide some tweaks for the Strave Website.
+This Firefox Add-on aims to provide some tweaks for the Strava Website.
 
 ## Give Kudos to All
 
-A button in the upper left of the every Strava page can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!
+A button in the upper left of every Strava page can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!

--- a/data/strava.css
+++ b/data/strava.css
@@ -1,11 +1,11 @@
 div#strava-helper-kudos-all-button {
     z-index: 1000;
-    position: fixed;
-    top: 5px;
-    left: 5px;
-    width: 35px;
-    height: 35px;
-    line-height: 35px;
+    position: absolute;
+    right: 185px;
+    top: 0;
+    width: 32px;
+    height: 32px;
+    line-height: 32px;
     text-align: center;
     background: #fff;
     border: 1px solid #ccc;
@@ -15,6 +15,5 @@ div#strava-helper-kudos-all-button {
 }
 
 div#strava-helper-kudos-all-button:hover {
-    background: #eee;
-    border: 2px solid #fff;
+    background: #F5F5F5;
 }

--- a/data/strava.js
+++ b/data/strava.js
@@ -6,8 +6,9 @@ jQuery(function($) {
     mjaschen.strava = {
 
         init : function() {
-            mjaschen.strava.createKudosToAllButton();
-            $(document).on("click", "#strava-helper-kudos-all-button", mjaschen.strava.giveKudosToAll);
+            if (mjaschen.strava.isLoggedIn()) {
+                mjaschen.strava.createKudosToAllButton();
+            }
 
             mjaschen.strava.removeClutter();
             mjaschen.strava.fixUi();
@@ -18,7 +19,8 @@ jQuery(function($) {
                 .attr("id", "strava-helper-kudos-all-button")
                 .attr("title", "Give Kudos to all visible items.")
                 .text("👍");
-            $("body").prepend($kudosAllButton);
+            $(".feed-settings").append($kudosAllButton);
+            $(document).on("click", "#strava-helper-kudos-all-button", mjaschen.strava.giveKudosToAll);
         },
 
         giveKudosToAll : function() {

--- a/data/strava.js
+++ b/data/strava.js
@@ -8,6 +8,9 @@ jQuery(function($) {
         init : function() {
             mjaschen.strava.createKudosToAllButton();
             $(document).on("click", "#strava-helper-kudos-all-button", mjaschen.strava.giveKudosToAll);
+
+            mjaschen.strava.removeClutter();
+            mjaschen.strava.fixUi();
         },
 
         createKudosToAllButton : function() {
@@ -29,8 +32,71 @@ jQuery(function($) {
 
         changeButtonText : function(text) {
             $("#strava-helper-kudos-all-button").text(text);
-        }
+        },
 
+        removeClutter: function() {
+            mjaschen.strava.removeFindFriends();
+            mjaschen.strava.removeUpcomingEvents();
+            mjaschen.strava.removeDiscoverySuggestions();
+            mjaschen.strava.removeFollowSuggestions();
+            mjaschen.strava.removePromotionalFooter();
+            mjaschen.strava.removeShopLink();
+            mjaschen.strava.removeGetPremiumLink();
+            mjaschen.strava.removeShareDropdown();
+            mjaschen.strava.removeCreateTargetButton();
+            mjaschen.strava.removeSharingButtons();
+        },
+
+        fixUi: function() {
+            $('.container > header').css({'position': 'fixed', 'top': '0', 'height': '55px'});
+            $('.container > .page').css({'top': '55px'});
+        },
+
+        removeFindFriends: function() {
+            $('#invite-your-friend-module').remove();
+        },
+
+        removeUpcomingEvents: function() {
+            $('#upcoming-events').remove();
+        },
+
+        removeDiscoverySuggestions: function() {
+            $('#discover-more').remove();
+        },
+
+        removeFollowSuggestions: function() {
+            $('#suggested-follow-module').remove();
+        },
+
+        removePromotionalFooter: function() {
+            $('.footer-promos').remove();
+        },
+
+        removeShopLink: function() {
+            if (mjaschen.strava.isLoggedIn()) {
+                $('.global-nav li:last-child').remove();
+            }
+        },
+
+        removeGetPremiumLink: function() {
+            $('.user-nav > li.upgrade').remove();
+        },
+
+        removeShareDropdown: function() {
+            $('.drop-down-menu.share').remove();
+        },
+
+        removeCreateTargetButton: function() {
+            $('.primary-stats > .upsell-sm').remove();
+        },
+
+        removeSharingButtons: function() {
+            $('.sharing').remove();
+        },
+
+        isLoggedIn: function() {
+            return $('.user-menu').length > 0;
+        }
     }
 
     mjaschen.strava.init();


### PR DESCRIPTION
Elements removed from dashboard and activity detail page:
- "Find friends"
- "Upcoming events"
- "Discover more"
- "Follow suggestions"
- Promotional footer at the bottom
- "Shop" link
- "Get Premium" link
- Social media dropdown menu in activity feed
- "Create target" link
- Social media buttons on activity detail page

Top navigation fixed to the top of the window.

Moved "give kudos to all" button to the activity page heading, next to the dropdown menu.
