### PR TITLE
Remove clutter from dashboard and activity page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ This Firefox Add-on aims to provide some tweaks for the Strava Website.
 ## Give Kudos to All
 
 A button in the upper left of every Strava page can be used to give Kudos to all visible activities. It saves you a lot of time and your Strava friends get the litte dose of motivation they deserve!
+
+## Remove Clutter
+
+Removes all social media and premium clutter from the dashboard and activity pages, such as:
+
+- "Find friends"
+- "Upcoming events"
+- "Discover more"
+- "Follow suggestions"
+- Promotional footer at the bottom
+- "Shop" link
+- "Get Premium" link
+- Social media dropdown menu in activity feed
+- "Create target" link
+- Social media buttons on activity detail page

--- a/data/strava.js
+++ b/data/strava.js
@@ -8,6 +8,8 @@ Zepto(function($) {
         init : function() {
             mjaschen.strava.createKudosToAllButton();
             $(document).on("click", "#strava-helper-kudos-all-button", mjaschen.strava.giveKudosToAll);
+
+            mjaschen.strava.removeClutter();
         },
 
         createKudosToAllButton : function() {
@@ -29,6 +31,65 @@ Zepto(function($) {
 
         changeButtonText : function(text) {
             $("#strava-helper-kudos-all-button").text(text);
+        },
+
+        removeClutter: function() {
+            mjaschen.strava.removeFindFriends();
+            mjaschen.strava.removeUpcomingEvents();
+            mjaschen.strava.removeDiscoverySuggestions();
+            mjaschen.strava.removeFollowSuggestions();
+            mjaschen.strava.removePromotionalFooter();
+            mjaschen.strava.removeShopLink();
+            mjaschen.strava.removeGetPremiumLink();
+            mjaschen.strava.removeShareDropdown();
+            mjaschen.strava.removeCreateTargetButton();
+            mjaschen.strava.removeSharingButtons();
+        },
+
+        removeFindFriends: function() {
+            $('#invite-your-friend-module').remove();
+        },
+
+        removeUpcomingEvents: function() {
+            $('#upcoming-events').remove();
+        },
+
+        removeDiscoverySuggestions: function() {
+            $('#discover-more').remove();
+        },
+
+        removeFollowSuggestions: function() {
+            $('#suggested-follow-module').remove();
+        },
+
+        removePromotionalFooter: function() {
+            $('.footer-promos').remove();
+        },
+
+        removeShopLink: function() {
+            if (mjaschen.strava.isLoggedIn()) {
+                $('.global-nav li:last-child').remove();
+            }
+        },
+
+        removeGetPremiumLink: function() {
+            $('.user-nav > li.upgrade').remove();
+        },
+
+        removeShareDropdown: function() {
+            $('.drop-down-menu.share').remove();
+        },
+
+        removeCreateTargetButton: function() {
+            $('.primary-stats > .upsell-sm').remove();
+        },
+
+        removeSharingButtons: function() {
+            $('.sharing').remove();
+        },
+
+        isLoggedIn: function() {
+            return $('.user-menu').length > 0;
         }
 
     }


### PR DESCRIPTION
Elements removed from dashboard and activity detail page:
- "Find friends"
- "Upcoming events"
- "Discover more"
- "Follow suggestions"
- Promotional footer at the bottom
- "Shop" link
- "Get Premium" link
- Social media dropdown menu in activity feed
- "Create target" link
- Social media buttons on activity detail page
